### PR TITLE
fix: add fallback to repo variable

### DIFF
--- a/src/app/config/getCIVars.js
+++ b/src/app/config/getCIVars.js
@@ -35,7 +35,7 @@ const getCIVars = env => {
     commitSha = env.CI_COMMIT_SHA || env.GIT_COMMIT || commitSha
     repoCurrentBranch = env.CI_BRANCH || env.GIT_BRANCH || repoCurrentBranch
     repoBranchBase = env.CI_BRANCH_BASE || repoBranchBase
-    repo = env.CI_REPO_NAME
+    repo = env.CI_REPO_NAME || repo
 
     if (!repo) {
         const gitUrl = env.GIT_URL


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR provides a bugfix for the Travis CI environment.

**Did you add tests for your changes?**

no

**Summary**

After following the docs for the setup of bundlewatch through Travis CI I always got the following error message:

```
[WARNING] Some CI configuration options were not found (repoOwner, repoName):
    bundlewatch will be unable to report build status, or save comparison data
    Learn more at: http://bundlewatch.io/#/getting-started/the-best-parts
```

After researching a little bit I noticed that the repo variable always gets overriden by the CI Variable `CI_REPO_NAME` [at this point](https://github.com/bundlewatch/bundlewatch/blob/master/src/app/config/getCIVars.js#L38) but the Travis CI environment doesn't provides a value for this variable according to [their docs](https://docs.travis-ci.com/user/environment-variables#default-environment-variables).

**Does this PR introduce a breaking change?**

no, it just adds a fallback value for the `repo` variable based on the Travis specific variables.

**Other information**
