### PR TITLE
Fix swapped around Travis branch env

### DIFF
--- a/src/app/config/getCIVars.js
+++ b/src/app/config/getCIVars.js
@@ -10,8 +10,8 @@ const getCIVars = env => {
     if (env.TRAVIS) {
         repo = env.TRAVIS_REPO_SLUG
         commitSha = env.TRAVIS_PULL_REQUEST_SHA || env.TRAVIS_COMMIT
-        repoCurrentBranch = env.TRAVIS_BRANCH
-        repoBranchBase = env.TRAVIS_PULL_REQUEST_BRANCH
+        repoCurrentBranch = env.TRAVIS_PULL_REQUEST_BRANCH
+        repoBranchBase = env.TRAVIS_BRANCH
     } else if (env.CIRCLECI) {
         repoOwner = env.CIRCLE_PROJECT_USERNAME
         repoName = env.CIRCLE_PROJECT_REPONAME


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- Fix reading from Travis env variables to infer the branches

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No, there is no existing test.
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from bundlewatch/bundlewatch.io here, or N/A -->

**Summary**
It fixes reading the wrong thing from Travis branch environment.

With the current code, with a PR from `some-branch` to `master`:
- `repoCurrentBranch === 'master'`
- `repoBranchBase === 'some-branch'`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
It should not
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
