### PR TITLE
Extract GitHub Actions branch name from GTIHUB_REF

### DIFF
--- a/src/app/config/getCIVars.js
+++ b/src/app/config/getCIVars.js
@@ -32,7 +32,8 @@ const getCIVars = env => {
         repoOwner = env.GITHUB_REPOSITORY.split('/')[0]
         repoName = env.GITHUB_REPOSITORY.split('/')[1]
         commitSha = env.GITHUB_SHA
-        repoCurrentBranch = env.GITHUB_REF
+        // GitHub only provides ref (read more: https://stackoverflow.com/q/1526471)
+        repoCurrentBranch = env.GITHUB_REF.replace(/^refs\/heads\//, '')
     }
     // Take CI preffered vars over everything
     repoOwner = env.CI_REPO_OWNER || repoOwner

--- a/src/app/config/getCIVars.test.js
+++ b/src/app/config/getCIVars.test.js
@@ -5,6 +5,7 @@ describe(`getCIVars`, () => {
     const mockRepoName = 'reponame_mock'
     const mockRepo = `${mockRepoOwner}/${mockRepoName}`
     const mockBranchBase = `mock_branch_base`
+    const mockRef = `refs/heads/mock_branch_base`
     const mockCommitSha = `ffac537e6cbbf934b08745a378932722df287a53`
 
     it(`Extracts GIT_URL (ssh) correct`, () => {
@@ -39,7 +40,7 @@ describe(`getCIVars`, () => {
             GITHUB_ACTIONS: true,
             GITHUB_REPOSITORY: mockRepo,
             GITHUB_SHA: mockCommitSha,
-            GITHUB_REF: mockBranchBase,
+            GITHUB_REF: mockRef,
         })
         expect(ciVars.repoOwner).toBe(mockRepoOwner)
         expect(ciVars.repoName).toBe(mockRepoName)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes #65 

**Did you add tests for your changes?**

Yes

**Summary**

GitHub only provides `GITHUB_REF` env variable which contains ref, not branch name. Here's the difference between ref and branch name: https://stackoverflow.com/q/1526471

Here's the relates SO question: https://stackoverflow.com/q/58033366