### PR TITLE
Fix TypeError: Cannot read property 'bundlewatch' of undefined in `determineConfig.js`

### DIFF
--- a/src/bin/determineConfig.js
+++ b/src/bin/determineConfig.js
@@ -52,8 +52,8 @@ const getConfigFileContents = (configFilePath) => {
 }
 
 const determineConfig = (cliOptions) => {
-    const pkgJson = (readPkgUp.sync() || {}).packageJson
-    let pkgJsonbundlewatch = pkgJson.bundlewatch
+    const pkgJson = (readPkgUp.sync() || { packageJson: {} }).packageJson
+    const pkgJsonbundlewatch = pkgJson.bundlewatch
 
     if (cliOptions.args && cliOptions.args.length > 0) {
         if (pkgJsonbundlewatch) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix.

**Did you add tests for your changes?**
No :( There were no tests for `determineConfig.js` 😞 

**Summary**
I wanted to run bundlewatch on a built project using `npx`. There's no `package.json` file there since I run it against _"webpacked"_ and _"minified"_ files. 

I noticed that in the source code there might be a bug when running `determineConfig.js:55` if there's no `package.json` found. The code seems to fallback to an empty object, and tries to reference `packageJson` from it. It'll be undefined and in the line below we try to get `pkgJson.bundlewatch` which will cause `Cannot read property 'bundlewatch' of undefined`

**Does this PR introduce a breaking change?**
No, it doesn't.

**Other information**
I won't lie - I wasn't able to run all the tests and checks that are provided in this repository since I don't have `nvm` and I'm using Node in version `v13.3.0`.
I wasn't able to test if even with this change one could run `bundlewatch` with `npx` on directory without `package.json`.
Nevertheless, the change seemed simple enough that I thought that you mind find it useful so I decided to open this PR - but feel free to close it and not merge it. 