### PR TITLE
feat: Allow filepaths in reports to be normalized (e.g. remove content hashes)

### DIFF
--- a/__testdata__/test.x1y2z3h4sh.bundle.js
+++ b/__testdata__/test.x1y2z3h4sh.bundle.js
@@ -1,0 +1,2 @@
+// this file exists to test filepath normalization (hashes in paths)
+// https://github.com/bundlewatch/bundlewatch/issues/30

--- a/src/app/getLocalFileDetails/index.js
+++ b/src/app/getLocalFileDetails/index.js
@@ -3,8 +3,15 @@ import glob from 'glob'
 import getSize from './getSize'
 import logger from '../../logger'
 
-const getLocalFileDetails = ({ files, defaultCompression }) => {
+const getLocalFileDetails = ({
+    files,
+    defaultCompression,
+    pathNormalizationPattern,
+    pathNoramlizationReplacement,
+}) => {
     const fileDetails = {}
+    const pathNormalizationPatternRegExp =
+        pathNormalizationPattern && new RegExp(pathNormalizationPattern)
 
     files.forEach((file) => {
         const paths = glob.sync(file.path)
@@ -22,9 +29,15 @@ const getLocalFileDetails = ({ files, defaultCompression }) => {
                     filePath,
                     compression,
                 })
+                const normalizedFilePath = pathNormalizationPatternRegExp
+                    ? filePath.replace(
+                          pathNormalizationPatternRegExp,
+                          pathNoramlizationReplacement,
+                      )
+                    : filePath
 
                 if (size) {
-                    fileDetails[filePath] = {
+                    fileDetails[normalizedFilePath] = {
                         maxSize,
                         size,
                         compression,

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -11,10 +11,14 @@ const main = async ({
     bundlewatchServiceHost,
     ci,
     defaultCompression,
+    pathNormalizationPattern,
+    pathNoramlizationReplacement,
 }) => {
     const currentBranchFileDetails = getLocalFileDetails({
         files,
         defaultCompression: defaultCompression,
+        pathNormalizationPattern,
+        pathNoramlizationReplacement,
     })
 
     const bundlewatchService = new BundleWatchService({

--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -102,4 +102,23 @@ describe(`bundlewatch Node API`, () => {
         }
         expect(error).toMatchSnapshot()
     })
+
+    it('Normalizes hash when given a filenameNormalizationPattern and filenameNoramlizationReplacement', async () => {
+        const result = await bundlewatchApi({
+            files: [
+                {
+                    path: './__testdata__/*.js',
+                    maxSize: '100kB',
+                },
+            ],
+            defaultCompression: 'none',
+            pathNormalizationPattern: '^([.][^\\.]+[.])([^\\.]+)([.].+)',
+            pathNoramlizationReplacement: '$1[hash]$3',
+        })
+
+        delete result.url
+        expect(result.fullResults[0].filePath).toMatchInlineSnapshot(
+            `"./__testdata__/test.[hash].bundle.js"`,
+        )
+    })
 })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
This addresses https://github.com/bundlewatch/bundlewatch/issues/30 to allow file paths in reports be processed (mainly to normalize hashes) 

https://github.com/bundlewatch/bundlewatch/blob/3c2c49a37169b186f948b770d03e936c6c13e19a/src/app/index.test.js#L115-L116

Since both the pattern and replacement are passed in, this config makes no assumptions about where hashes exists in the path


**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Yes

**If relevant, link to documentation update:**

<!-- Link PR from bundlewatch/bundlewatch.io here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Motivation is summarized pretty well in https://github.com/bundlewatch/bundlewatch/issues/30
Bundle often contain hashes in the path name, not being able to compare across versions of the same file cripples the usefulness of the file size watcher

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

