### PR TITLE
feat: Add filename normalizing

### DIFF
--- a/src/app/analyze/analyze.test.js
+++ b/src/app/analyze/analyze.test.js
@@ -1,4 +1,8 @@
-import { getOverallDifference, getPercentageChangeString } from '.'
+import {
+    getOverallDifference,
+    getPercentageChangeString,
+    normalizeFilename,
+} from '.'
 import { mockFileResults } from './analyze.test.mockdata'
 
 describe('getOverallDifference', () => {
@@ -72,5 +76,33 @@ describe('getPercentageChangeString', () => {
 
     it('Fixes to one decimal place', () => {
         expect(getPercentageChangeString(1.2345)).toEqual('+1.2%')
+    })
+})
+
+describe('normalizeFilename', () => {
+    const toResult = (name) => ({ filePath: name })
+
+    // anything(.hash).js
+    const removeHashRegex = /^.+?(\.\w+)\.js$/
+    // anything(test)anything(test).js
+    const testRegex = /^.+?(test).+?(test)\.js$/
+
+    // prettier-ignore
+    const cases = [
+        // filename,                regex,              result
+        ['file.js',                 removeHashRegex,    'file.js'],
+        ['something.js',            removeHashRegex,    'something.js'],
+        ['wow.js',                  removeHashRegex,    'wow.js'],
+        ['main.6c70c5d5.js',        removeHashRegex,    'main.js'],
+        ['debugger.7bad0121.js',    removeHashRegex,    'debugger.js'],
+        ['finished.74119b14.js',    removeHashRegex,    'finished.js'],
+        ['file.js',                 testRegex,          'file.js'],
+        ['lalatestlalatest.js',     testRegex,          'lalalala.js'],
+    ]
+
+    it.each(cases)('%s + %p -> %s', (filename, regex, result) => {
+        expect(normalizeFilename(regex)(toResult(filename)).filePath).toBe(
+            result,
+        )
     })
 })

--- a/src/app/analyze/index.js
+++ b/src/app/analyze/index.js
@@ -83,7 +83,7 @@ const getSummary = ({ overallStatus, fullResults, baseBranchName }) => {
     return `Everything is in check ${differenceSummary}`
 }
 
-const normalize = (normalizeFilenames) => (result) => {
+export const normalizeFilename = (normalizeFilenames) => (result) => {
     let filename = basename(result.filePath)
     const [, ...matches] = filename.match(normalizeFilenames) ?? []
 
@@ -111,7 +111,7 @@ const analyze = ({
     })
 
     if (normalizeFilenames != null) {
-        fileResults = fileResults.map(normalize(normalizeFilenames))
+        fileResults = fileResults.map(normalizeFilename(normalizeFilenames))
     }
 
     const overallStatus = getOverallStatus(fileResults)

--- a/src/app/analyze/index.js
+++ b/src/app/analyze/index.js
@@ -1,4 +1,5 @@
 import bytes from 'bytes'
+import { basename } from 'path'
 import analyzeFiles, { STATUSES } from './analyzeFiles'
 
 const getOverallStatus = (fileResults) => {
@@ -82,16 +83,36 @@ const getSummary = ({ overallStatus, fullResults, baseBranchName }) => {
     return `Everything is in check ${differenceSummary}`
 }
 
+const normalize = (normalizeFilenames) => (result) => {
+    let filename = basename(result.filePath)
+    const [, ...matches] = filename.match(normalizeFilenames) ?? []
+
+    let normalized = filename
+    matches.forEach((match) => {
+        normalized = normalized.replace(match, '')
+    })
+
+    return {
+        ...result,
+        filePath: result.filePath.slice(0, -filename.length) + normalized,
+    }
+}
+
 const analyze = ({
     currentBranchFileDetails,
     baseBranchFileDetails,
     baseBranchName,
+    normalizeFilenames,
 }) => {
-    const fileResults = analyzeFiles({
+    let fileResults = analyzeFiles({
         currentBranchFileDetails,
         baseBranchFileDetails,
         baseBranchName,
     })
+
+    if (normalizeFilenames != null) {
+        fileResults = fileResults.map(normalize(normalizeFilenames))
+    }
 
     const overallStatus = getOverallStatus(fileResults)
     const summary = getSummary({

--- a/src/app/config/ensureValid.js
+++ b/src/app/config/ensureValid.js
@@ -26,6 +26,23 @@ const ensureDefaultCompressionValid = (config) => {
     return config
 }
 
+/* eslint-disable no-param-reassign */
+const ensureNormalizeFilenamesValid = (config) => {
+    const input = config.normalizeFilenames
+    if (input == null) return config
+
+    if (typeof input === 'string') {
+        config.normalizeFilenames = new RegExp(input)
+    } else if (!(input instanceof RegExp)) {
+        throw new Error('config.normalizeFilenames is not a valid RegExp.')
+    }
+
+    config.normalizeFilenames = new RegExp(input, 'g')
+
+    return config
+}
+/* eslint-enable */
+
 const ensureCiValid = (config) => {
     if (!Array.isArray(config.ci.trackBranches)) {
         throw new ValidationError('config.ci.trackBranches must be an Array')
@@ -83,6 +100,7 @@ const validators = [
     ensureCiValid,
 ]
 
+// Runs and returns the result of each validator
 const ensureValid = (config) =>
     validators.reduce((c, validator) => validator(c), config)
 

--- a/src/app/config/ensureValid.js
+++ b/src/app/config/ensureValid.js
@@ -31,10 +31,18 @@ const ensureNormalizeFilenamesValid = (config) => {
     if (input == null) return config
 
     if (typeof input === 'string') {
-        // eslint-disable-next-line no-param-reassign
-        config.normalizeFilenames = new RegExp(input)
+        try {
+            // eslint-disable-next-line no-param-reassign
+            config.normalizeFilenames = new RegExp(input)
+        } catch (e) {
+            throw new Error(
+                `config.normalizeFilenames (${input}) is not a valid RegExp.`,
+            )
+        }
     } else if (!(input instanceof RegExp)) {
-        throw new Error('config.normalizeFilenames is not a valid RegExp.')
+        throw new Error(
+            `config.normalizeFilenames (${input}) is not a valid RegExp.`,
+        )
     }
 
     return config

--- a/src/app/config/ensureValid.js
+++ b/src/app/config/ensureValid.js
@@ -14,12 +14,16 @@ const ensureFilesValid = (config) => {
     //     maxSize, // basically required (defaults to Infinity)
     //     compression, // optional
     // }
+
+    return config
 }
 
 const ensureDefaultCompressionValid = (config) => {
     if (!COMPRESSION_TYPES.includes(config.defaultCompression)) {
         throw new ValidationError('config.compression must be a valid type')
     }
+
+    return config
 }
 
 const ensureCiValid = (config) => {
@@ -68,12 +72,18 @@ const ensureCiValid = (config) => {
     Learn more at: https://bundlewatch.io/
         `)
     }
+
+    return config
 }
 
-const ensureValid = (config) => {
-    ensureFilesValid(config)
-    ensureDefaultCompressionValid(config)
-    ensureCiValid(config)
-}
+const validators = [
+    ensureFilesValid,
+    ensureDefaultCompressionValid,
+    ensureNormalizeFilenamesValid,
+    ensureCiValid,
+]
+
+const ensureValid = (config) =>
+    validators.reduce((c, validator) => validator(c), config)
 
 export default ensureValid

--- a/src/app/config/ensureValid.js
+++ b/src/app/config/ensureValid.js
@@ -4,7 +4,7 @@ import logger from '../../logger'
 
 const COMPRESSION_TYPES = ['gzip', 'brotli', 'none']
 
-const ensureValid = (config) => {
+const ensureFilesValid = (config) => {
     if (!Array.isArray(config.files)) {
         throw new ValidationError('config.files must be an Array')
     }
@@ -14,11 +14,15 @@ const ensureValid = (config) => {
     //     maxSize, // basically required (defaults to Infinity)
     //     compression, // optional
     // }
+}
 
+const ensureDefaultCompressionValid = (config) => {
     if (!COMPRESSION_TYPES.includes(config.defaultCompression)) {
         throw new ValidationError('config.compression must be a valid type')
     }
+}
 
+const ensureCiValid = (config) => {
     if (!Array.isArray(config.ci.trackBranches)) {
         throw new ValidationError('config.ci.trackBranches must be an Array')
     }
@@ -64,6 +68,12 @@ const ensureValid = (config) => {
     Learn more at: https://bundlewatch.io/
         `)
     }
+}
+
+const ensureValid = (config) => {
+    ensureFilesValid(config)
+    ensureDefaultCompressionValid(config)
+    ensureCiValid(config)
 }
 
 export default ensureValid

--- a/src/app/config/ensureValid.js
+++ b/src/app/config/ensureValid.js
@@ -26,22 +26,19 @@ const ensureDefaultCompressionValid = (config) => {
     return config
 }
 
-/* eslint-disable no-param-reassign */
 const ensureNormalizeFilenamesValid = (config) => {
     const input = config.normalizeFilenames
     if (input == null) return config
 
     if (typeof input === 'string') {
+        // eslint-disable-next-line no-param-reassign
         config.normalizeFilenames = new RegExp(input)
     } else if (!(input instanceof RegExp)) {
         throw new Error('config.normalizeFilenames is not a valid RegExp.')
     }
 
-    config.normalizeFilenames = new RegExp(input, 'g')
-
     return config
 }
-/* eslint-enable */
 
 const ensureCiValid = (config) => {
     if (!Array.isArray(config.ci.trackBranches)) {

--- a/src/app/config/getConfig.js
+++ b/src/app/config/getConfig.js
@@ -22,8 +22,8 @@ const defaultConfig = {
 
 const getConfig = (customConfig) => {
     const config = lodashMerge({}, defaultConfig, customConfig)
-    ensureValid(config)
-    return config
+
+    return ensureValid(config)
 }
 
 export default getConfig

--- a/src/app/config/getConfig.js
+++ b/src/app/config/getConfig.js
@@ -6,6 +6,7 @@ import ensureValid from './ensureValid'
 const ciVars = getCIVars(process.env)
 
 const defaultConfig = {
+    normalizeFilenames: null,
     files: [],
     bundlewatchServiceHost: 'https://service.bundlewatch.io', // Can be a custom service, or set to NUll
     ci: {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -11,6 +11,7 @@ const main = async ({
     bundlewatchServiceHost,
     ci,
     defaultCompression,
+    normalizeFilenames,
 }) => {
     const currentBranchFileDetails = getLocalFileDetails({
         files,
@@ -37,6 +38,7 @@ const main = async ({
         currentBranchFileDetails,
         baseBranchFileDetails,
         baseBranchName: ci.repoBranchBase,
+        normalizeFilenames,
     })
 
     const url = await createURLToResultPage({

--- a/src/bin/determineConfig.js
+++ b/src/bin/determineConfig.js
@@ -77,6 +77,7 @@ const determineConfig = (cliOptions) => {
         return {
             files,
             defaultCompression: cliOptions.compression || 'gzip',
+            normalizeFilenames: cliOptions.normalize,
         }
     }
 

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -104,6 +104,10 @@ program
         '--compression [compression]',
         'specify which compression algorithm to use',
     )
+    .option(
+        '--normalize [regex]',
+        'normalize filenames via regex, any match will be removed',
+    )
 
 program.on('--help', () => {
     logger.log('')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Feature

**Did you add tests for your changes?**

I added some tests for the normalizing, but couldn't find any way to test it further than I did. Please let me know if anything else should be added.

**If relevant, link to documentation update:**

*TODO*

**Summary**

Some bundles may have hashes in their filenames - this breaks comparisons since files appear to be deleted instead of modified when the hashes change.

This adds an option for normalizing these filenames to fix this iseue.

I also thought about adding an enum option, so you can easily remove hashes without having to write a new Regex for it.

e.g.

```
$ yarn bundlewatch --normalize hash
```

**Does this PR introduce a breaking change?**

No

**Other information**

While adding the config, I made the validators able to alter the configuration to be valid to easily parse string regexes from JSON files or CLI options.
