### PR TITLE
fix: file path normalization wasn't working right

### DIFF
--- a/__testdata__/test.bundle.x1y2z3h4sh.js
+++ b/__testdata__/test.bundle.x1y2z3h4sh.js
@@ -1,0 +1,2 @@
+// this file exists to test filepath normalization (hashes in paths)
+// https://github.com/bundlewatch/bundlewatch/issues/30

--- a/src/app/analyze/analyze.test.js
+++ b/src/app/analyze/analyze.test.js
@@ -1,8 +1,4 @@
-import {
-    getOverallDifference,
-    getPercentageChangeString,
-    normalizeFilename,
-} from '.'
+import { getOverallDifference, getPercentageChangeString } from '.'
 import { mockFileResults } from './analyze.test.mockdata'
 
 describe('getOverallDifference', () => {
@@ -76,33 +72,5 @@ describe('getPercentageChangeString', () => {
 
     it('Fixes to one decimal place', () => {
         expect(getPercentageChangeString(1.2345)).toEqual('+1.2%')
-    })
-})
-
-describe('normalizeFilename', () => {
-    const toResult = (name) => ({ filePath: name })
-
-    // anything(.hash).js
-    const removeHashRegex = /^.+?(\.\w+)\.js$/
-    // anything(test)anything(test).js
-    const testRegex = /^.+?(test).+?(test)\.js$/
-
-    // prettier-ignore
-    const cases = [
-        // filename,                regex,              result
-        ['file.js',                 removeHashRegex,    'file.js'],
-        ['something.js',            removeHashRegex,    'something.js'],
-        ['wow.js',                  removeHashRegex,    'wow.js'],
-        ['main.6c70c5d5.js',        removeHashRegex,    'main.js'],
-        ['debugger.7bad0121.js',    removeHashRegex,    'debugger.js'],
-        ['finished.74119b14.js',    removeHashRegex,    'finished.js'],
-        ['file.js',                 testRegex,          'file.js'],
-        ['lalatestlalatest.js',     testRegex,          'lalalala.js'],
-    ]
-
-    it.each(cases)('%s + %p -> %s', (filename, regex, result) => {
-        expect(normalizeFilename(regex)(toResult(filename)).filePath).toBe(
-            result,
-        )
     })
 })

--- a/src/app/analyze/index.js
+++ b/src/app/analyze/index.js
@@ -1,5 +1,4 @@
 import bytes from 'bytes'
-import { basename } from 'path'
 import analyzeFiles, { STATUSES } from './analyzeFiles'
 
 const getOverallStatus = (fileResults) => {
@@ -83,36 +82,16 @@ const getSummary = ({ overallStatus, fullResults, baseBranchName }) => {
     return `Everything is in check ${differenceSummary}`
 }
 
-export const normalizeFilename = (normalizeFilenames) => (result) => {
-    let filename = basename(result.filePath)
-    const [, ...matches] = filename.match(normalizeFilenames) ?? []
-
-    let normalized = filename
-    matches.forEach((match) => {
-        normalized = normalized.replace(match, '')
-    })
-
-    return {
-        ...result,
-        filePath: result.filePath.slice(0, -filename.length) + normalized,
-    }
-}
-
 const analyze = ({
     currentBranchFileDetails,
     baseBranchFileDetails,
     baseBranchName,
-    normalizeFilenames,
 }) => {
     let fileResults = analyzeFiles({
         currentBranchFileDetails,
         baseBranchFileDetails,
         baseBranchName,
     })
-
-    if (normalizeFilenames != null) {
-        fileResults = fileResults.map(normalizeFilename(normalizeFilenames))
-    }
 
     const overallStatus = getOverallStatus(fileResults)
     const summary = getSummary({

--- a/src/app/getLocalFileDetails/index.js
+++ b/src/app/getLocalFileDetails/index.js
@@ -3,7 +3,11 @@ import glob from 'glob'
 import getSize from './getSize'
 import logger from '../../logger'
 
-const getLocalFileDetails = ({ files, defaultCompression }) => {
+const getLocalFileDetails = ({
+    files,
+    defaultCompression,
+    normalizeFilenames,
+}) => {
     const fileDetails = {}
 
     files.forEach((file) => {
@@ -22,9 +26,24 @@ const getLocalFileDetails = ({ files, defaultCompression }) => {
                     filePath,
                     compression,
                 })
+                const normalizedFilePath = normalizeFilenames
+                    ? // remove matched capture groups
+                      filePath
+                          // find all matching segments
+                          .split(normalizeFilenames)
+                          .reduce(
+                              (partiallyNormalizedPath, matchingSegment) =>
+                                  // remove matching segment from normalized path
+                                  partiallyNormalizedPath.replace(
+                                      matchingSegment,
+                                      '',
+                                  ),
+                              filePath,
+                          )
+                    : filePath
 
                 if (size) {
-                    fileDetails[filePath] = {
+                    fileDetails[normalizedFilePath] = {
                         maxSize,
                         size,
                         compression,

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -38,7 +38,6 @@ const main = async ({
         currentBranchFileDetails,
         baseBranchFileDetails,
         baseBranchName: ci.repoBranchBase,
-        normalizeFilenames,
     })
 
     const url = await createURLToResultPage({

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -16,6 +16,7 @@ const main = async ({
     const currentBranchFileDetails = getLocalFileDetails({
         files,
         defaultCompression: defaultCompression,
+        normalizeFilenames,
     })
 
     const bundlewatchService = new BundleWatchService({

--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -102,4 +102,22 @@ describe(`bundlewatch Node API`, () => {
         }
         expect(error).toMatchSnapshot()
     })
+
+    it('Normalizes hash when given a normalizeFilenames option', async () => {
+        const result = await bundlewatchApi({
+            files: [
+                {
+                    path: './__testdata__/*.js',
+                    maxSize: '100kB',
+                },
+            ],
+            defaultCompression: 'none',
+            normalizeFilenames: '^.+?(\\.\\w+)\\.(?:js|css)$',
+        })
+
+        delete result.url
+        expect(result.fullResults[0].filePath).toMatchInlineSnapshot(
+            `"./__testdata__/test.bundle.js"`,
+        )
+    })
 })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
yes

**If relevant, link to documentation update:**

<!-- Link PR from bundlewatch/bundlewatch.io here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
following up to https://github.com/bundlewatch/bundlewatch/pull/214 
We're currently generating confusing reports where the file names show up as the same but they're not compared against their previous version
![](https://user-images.githubusercontent.com/472500/93329440-7d691480-f81d-11ea-9cb5-b0df657d13aa.png)


It looks like we needed to perform normalization earlier than when `analyze` was called, since there's a call to `bundlewatchService.saveFileDetailsForCurrentBranch` before `analyze` is run  
 
https://github.com/bundlewatch/bundlewatch/blob/57c71deedfd780fb61dd4f31537a07c27d6da350/src/app/index.js#L31-L42



**Does this PR introduce a breaking change?**
No, the API is kept the same as before (any captured segments are removed)
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
