### PR TITLE
fix: skip directories in matched file paths

### DIFF
--- a/src/app/getLocalFileDetails/index.js
+++ b/src/app/getLocalFileDetails/index.js
@@ -1,5 +1,6 @@
 import bytes from 'bytes'
 import glob from 'glob'
+import fs from 'fs'
 import getSize from './getSize'
 import logger from '../../logger'
 
@@ -20,6 +21,7 @@ const getLocalFileDetails = ({
             }
         } else {
             paths.forEach((filePath) => {
+                if (fs.lstatSync(filePath).isDirectory()) { return }
                 const maxSize = bytes(file.maxSize) || Infinity
                 const compression = file.compression || defaultCompression
                 const size = getSize({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Could not find any unit tests in the codebase, am I missing something?

**If relevant, link to documentation update:**

<!-- Link PR from bundlewatch/bundlewatch.io here, or N/A -->

**Summary**
The current glob match will match directories that match your file globs, eg. a files entry of ``.nuxt/dist/client/**/*.css``

will match a file named ``.nuxt/dist/client/2.css/23r23.css``
but also a directory named `.nuxt/dist/client/2.css`` and will thus fail on this dir.

This change skips any directory that matches the provided glob.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

Not as far as I'm aware
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Couldn't find a great way to test this so could use some help validating that this change works as intended...
