### PR TITLE
Use specified CLI config

### DIFF
--- a/src/bin/determineConfig.js
+++ b/src/bin/determineConfig.js
@@ -52,6 +52,19 @@ const getConfigFileContents = (configFilePath) => {
 }
 
 const determineConfig = (cliOptions) => {
+    if (cliOptions.config) {
+        logger.warn(
+            `configFilePath supplied, config in package.json will be ignored`,
+        )
+        const config = getConfigFileContents(cliOptions.config)
+
+        if (!config || !config.bundlewatch) {
+            throw new ValidationError("bundlewatch is not defined in config")
+        }
+
+        return config.bundlewatch
+    }
+
     const pkgJson = (readPkgUp.sync() || {}).packageJson
     let pkgJsonbundlewatch = pkgJson.bundlewatch
 
@@ -81,14 +94,6 @@ const determineConfig = (cliOptions) => {
         }
     }
 
-    if (cliOptions.config) {
-        if (pkgJsonbundlewatch) {
-            logger.warn(
-                `configFilePath supplied, config in package.json will be ignored`,
-            )
-        }
-        return getConfigFileContents(cliOptions.config)
-    }
 
     if (pkgJsonbundlewatch) {
         if (Array.isArray(pkgJsonbundlewatch)) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes an existing feature that does not seem to work.

**Did you add tests for your changes?**

I haven't as yet but I also didn't break any tests, which means there weren't any for this part of the app! ;)

**Summary**
The documentation surrounding supplying a config file to the tool is misleading. I was following what the docs said and it was not working. When looking at the source I could see that the code was looking for the closest package.json file before processing any further. This caused 2 problems:

- It required a `bundlewatch` entry in package.json that seems redundant
- Even after supplying the entry, the subsequent code was then expecting a `config` property _within_ the `bundlewatch` config, which again seemed redundant.

I could very well be missing something though!

My change honours the config specified in the config. I think a further improvement would be to ditch the format of it being like a 'package.json' file. Instead it can simply mirror be the structure of what would be within the `bundlewatch` property. Happy to make this change. I think it's clearer and is more inline with what other projects use. Subsequently, bundlewatch.io docs should be updated as well. 

**Does this PR introduce a breaking change?**
Not that I can see
