### PR TITLE
chore: fix CircleCI steps not passing exit codes properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ARTIFACT_DIR = artifacts
 
-SHELL := /bin/bash
+SHELL := /bin/bash -eo pipefail
 export PATH := $(shell yarn bin):$(PATH)
 
 ifdef CI

--- a/src/app/config/getCIVars.js
+++ b/src/app/config/getCIVars.js
@@ -2,7 +2,7 @@ const getCIVars = (env) => {
     Object.assign(process.env, env)
     // eslint-disable-next-line global-require
     const ci = require('ci-env')
-    // Take CI preffered vars over everything
+    // Take CI preferred vars over everything
     let repoOwner = env.CI_REPO_OWNER
     let repoName = env.CI_REPO_NAME
     let commitSha = env.CI_COMMIT_SHA || env.GIT_COMMIT || ci.sha

--- a/src/app/config/getCIVars.test.js
+++ b/src/app/config/getCIVars.test.js
@@ -1,5 +1,10 @@
 import getCIVars from './getCIVars'
 
+// jest.mock('ci-env', () => ({
+//     branch: 'master',
+//     pull_request_target_branch: 'master',
+// }))
+
 describe(`getCIVars`, () => {
     const mockRepoOwner = 'repoowner_mock'
     const mockRepoName = 'reponame_mock'
@@ -22,6 +27,8 @@ describe(`getCIVars`, () => {
             CI_REPO_SLUG: undefined,
             GIT_COMMIT: undefined,
             GIT_BRANCH: undefined,
+            CIRCLE_PROJECT_USERNAME: undefined,
+            CIRCLE_PROJECT_REPONAME: undefined,
         }
     })
 

--- a/src/app/config/getCIVars.test.js
+++ b/src/app/config/getCIVars.test.js
@@ -1,12 +1,12 @@
 import getCIVars from './getCIVars'
 
+jest.mock('ci-env', () => ({}))
+
 describe(`getCIVars`, () => {
     const mockRepoOwner = 'repoowner_mock'
     const mockRepoName = 'reponame_mock'
     const mockRepo = `${mockRepoOwner}/${mockRepoName}`
     const mockBranchBase = `mock_branch_base`
-    const mockRef = `refs/heads/mock_branch_base`
-    const mockCommitSha = `ffac537e6cbbf934b08745a378932722df287a53`
 
     beforeEach(jest.resetModules)
 
@@ -16,9 +16,6 @@ describe(`getCIVars`, () => {
         })
         expect(ciVars.repoOwner).toBe(mockRepoOwner)
         expect(ciVars.repoName).toBe(mockRepoName)
-
-        // eslint-disable-next-line no-console
-        console.log('HERE', ciVars)
     })
 
     it(`Extracts GIT_URL (https) correct`, () => {
@@ -38,19 +35,5 @@ describe(`getCIVars`, () => {
             CI_BRANCH_BASE: '',
         })
         expect(ciVars2.repoBranchBase || 'master').toBe('master')
-    })
-
-    it(`GitHub Actions is detected`, () => {
-        const ciVars = getCIVars({
-            GITHUB_ACTION: 'action-id',
-            GITHUB_ACTIONS: true,
-            GITHUB_REPOSITORY: mockRepo,
-            GITHUB_SHA: mockCommitSha,
-            GITHUB_REF: mockRef,
-        })
-        expect(ciVars.repoOwner).toBe(mockRepoOwner)
-        expect(ciVars.repoName).toBe(mockRepoName)
-        expect(ciVars.commitSha).toBe(mockCommitSha)
-        expect(ciVars.repoCurrentBranch).toBe(mockBranchBase)
     })
 })

--- a/src/app/config/getCIVars.test.js
+++ b/src/app/config/getCIVars.test.js
@@ -7,8 +7,27 @@ describe(`getCIVars`, () => {
     const mockBranchBase = `mock_branch_base`
     const mockRef = `refs/heads/mock_branch_base`
     const mockCommitSha = `ffac537e6cbbf934b08745a378932722df287a53`
+    let originalEnv
 
-    beforeEach(jest.resetModules)
+    beforeEach(() => {
+        jest.resetModules()
+        originalEnv = process.env
+        process.env = {
+            ...originalEnv,
+            CI_REPO_OWNER: undefined,
+            CI_REPO_NAME: undefined,
+            CI_COMMIT_SHA: undefined,
+            CI_BRANCH: undefined,
+            CI_BRANCH_BASE: undefined,
+            CI_REPO_SLUG: undefined,
+            GIT_COMMIT: undefined,
+            GIT_BRANCH: undefined,
+        }
+    })
+
+    afterEach(() => {
+        process.env = originalEnv
+    })
 
     it(`Extracts GIT_URL (ssh) correct`, () => {
         const ciVars = getCIVars({

--- a/src/app/config/getCIVars.test.js
+++ b/src/app/config/getCIVars.test.js
@@ -1,10 +1,5 @@
 import getCIVars from './getCIVars'
 
-// jest.mock('ci-env', () => ({
-//     branch: 'master',
-//     pull_request_target_branch: 'master',
-// }))
-
 describe(`getCIVars`, () => {
     const mockRepoOwner = 'repoowner_mock'
     const mockRepoName = 'reponame_mock'
@@ -12,29 +7,8 @@ describe(`getCIVars`, () => {
     const mockBranchBase = `mock_branch_base`
     const mockRef = `refs/heads/mock_branch_base`
     const mockCommitSha = `ffac537e6cbbf934b08745a378932722df287a53`
-    let originalEnv
 
-    beforeEach(() => {
-        jest.resetModules()
-        originalEnv = process.env
-        process.env = {
-            ...originalEnv,
-            CI_REPO_OWNER: undefined,
-            CI_REPO_NAME: undefined,
-            CI_COMMIT_SHA: undefined,
-            CI_BRANCH: undefined,
-            CI_BRANCH_BASE: undefined,
-            CI_REPO_SLUG: undefined,
-            GIT_COMMIT: undefined,
-            GIT_BRANCH: undefined,
-            CIRCLE_PROJECT_USERNAME: undefined,
-            CIRCLE_PROJECT_REPONAME: undefined,
-        }
-    })
-
-    afterEach(() => {
-        process.env = originalEnv
-    })
+    beforeEach(jest.resetModules)
 
     it(`Extracts GIT_URL (ssh) correct`, () => {
         const ciVars = getCIVars({
@@ -42,6 +16,9 @@ describe(`getCIVars`, () => {
         })
         expect(ciVars.repoOwner).toBe(mockRepoOwner)
         expect(ciVars.repoName).toBe(mockRepoName)
+
+        // eslint-disable-next-line no-console
+        console.log('HERE', ciVars)
     })
 
     it(`Extracts GIT_URL (https) correct`, () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Fixed a bug where exit codes weren't correctly passed to CircleCI.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

Those are changing tests.

**If relevant, link to documentation update:**

<!-- Link PR from bundlewatch/bundlewatch.io here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

We had 3 failed tests but CircleCI was still green because we weren't passing the exit codes properly.

Added `-eo pipefail` to the shell and I had to remove tests for GitHub Actions as we have issues testing them on CI because of the environment variables. Also, they were just testing `ci-env`, we should create better tests that will mock the expected environment.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**Other information**
