### PR TITLE
fix: normalizing file paths accidentally returning empty file path

### DIFF
--- a/src/app/getLocalFileDetails/index.js
+++ b/src/app/getLocalFileDetails/index.js
@@ -26,21 +26,22 @@ const getLocalFileDetails = ({
                     filePath,
                     compression,
                 })
-                const normalizedFilePath = normalizeFilenames
-                    ? // remove matched capture groups
-                      filePath
-                          // find all matching segments
-                          .split(normalizeFilenames)
-                          .reduce(
-                              (partiallyNormalizedPath, matchingSegment) =>
-                                  // remove matching segment from normalized path
-                                  partiallyNormalizedPath.replace(
-                                      matchingSegment,
-                                      '',
-                                  ),
-                              filePath,
-                          )
-                    : filePath
+                const normalizedFilePath =
+                    normalizeFilenames && normalizeFilenames.test(filePath)
+                        ? // remove matched capture groups
+                          filePath
+                              // find all matching segments
+                              .split(normalizeFilenames)
+                              .reduce(
+                                  (partiallyNormalizedPath, matchingSegment) =>
+                                      // remove matching segment from normalized path
+                                      partiallyNormalizedPath.replace(
+                                          matchingSegment,
+                                          '',
+                                      ),
+                                  filePath,
+                              )
+                        : filePath
 
                 if (size) {
                     fileDetails[normalizedFilePath] = {

--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -117,6 +117,9 @@ describe(`bundlewatch Node API`, () => {
 
         delete result.url
         expect(result.fullResults[0].filePath).toMatchInlineSnapshot(
+            `"./__testdata__/test-stable-path.js"`,
+        )
+        expect(result.fullResults[1].filePath).toMatchInlineSnapshot(
             `"./__testdata__/test.bundle.js"`,
         )
     })


### PR DESCRIPTION
recommend reviewing with [whitespace turned off](https://github.com/bundlewatch/bundlewatch/pull/453/files?diff=unified&w=1)  
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This fixes a bug for projects using a mix of content-hashing and stable filenames where files without a hash are replaced with an empty path

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

yes


**Summary**
follow up to https://github.com/bundlewatch/bundlewatch/pull/214 and https://github.com/bundlewatch/bundlewatch/pull/238

It's possible for a build to contain both filepaths with hashes and filepaths that are stable (without hashes)

If a pattern provided via `normalizeFilenames` doesn't match the path (e.g. filepath does not contain a hash), currently the normalized path becomes an empty string 😱  additionally, reports fail with a message of `results.fullResults[0].filePath\" is not allowed to be empty`

**Does this PR introduce a breaking change?**

no
