### PR TITLE
feat: support mjs and cjs extensions

### DIFF
--- a/src/bin/determineConfig.js
+++ b/src/bin/determineConfig.js
@@ -45,7 +45,7 @@ const getConfigFileJS = (configFilePath) => {
 }
 
 const getConfigFileContents = (configFilePath) => {
-    if (configFilePath.endsWith('.js')) {
+    if (configFilePath.endsWith('.js') || configFilePath.endsWith('.cjs') || configFilePath.endsWith('.mjs')) {
         return getConfigFileJS(configFilePath)
     }
     return getConfigFileJson(configFilePath)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A feature.

**Did you add tests for your changes?**

No. There don't seem to be relevant tests for this yet.

**If relevant, link to documentation update:**

N/A

**Summary**

When passing a cjs or mjs file to the `--config` parameter, BundleWatch treats it as JSON because it only treats `.js` as JavaScript, and everything else as JSON.

**Does this PR introduce a breaking change?**

No.

**Other information**

N/A