### PR TITLE
Sending github error status on unhandled errors + Adding max timeout

### DIFF
--- a/src/app/config/getConfig.js
+++ b/src/app/config/getConfig.js
@@ -7,6 +7,7 @@ const ciVars = getCIVars(process.env)
 
 const defaultConfig = {
     normalizeFilenames: null,
+    maxTimeout: null,
     files: [],
     bundlewatchServiceHost: 'https://service.bundlewatch.io', // Can be a custom service, or set to NUll
     ci: {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,6 +1,5 @@
 import getLocalFileDetails from './getLocalFileDetails'
 import BundleWatchService from './reporting/BundleWatchService'
-import GitHubService from './reporting/GitHubService'
 import analyze from './analyze'
 import { STATUSES } from './analyze/analyzeFiles'
 import getConfig from './config/getConfig'
@@ -58,16 +57,8 @@ const main = async ({
     }
 }
 
-const bundlewatchApi = async (customConfig) => {
+const bundlewatchApi = async (customConfig, githubService) => {
     const config = getConfig(customConfig)
-    const githubService = new GitHubService({
-        repoOwner: config.ci.repoOwner,
-        repoName: config.ci.repoName,
-        commitSha: config.ci.commitSha,
-        githubAccessToken: config.ci.githubAccessToken,
-    })
-    await githubService.start({ message: 'Checking bundlewatch...' })
-
     try {
         const results = await main(config)
         if (results.status === STATUSES.FAIL) {

--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -7,15 +7,22 @@ import bundlewatchApi from '.'
 
 describe(`bundlewatch Node API`, () => {
     it('Works with basic options', async () => {
-        const result = await bundlewatchApi({
-            files: [
-                {
-                    path: './__testdata__/*.jpg',
-                    maxSize: '100kB',
-                },
-            ],
-            defaultCompression: 'none',
-        })
+        const result = await bundlewatchApi(
+            {
+                files: [
+                    {
+                        path: './__testdata__/*.jpg',
+                        maxSize: '100kB',
+                    },
+                ],
+                defaultCompression: 'none',
+            },
+            {
+                error: () => {},
+                pass: () => {},
+                fail: () => {},
+            },
+        )
 
         // TODO: assert logger.warn called
 
@@ -24,14 +31,21 @@ describe(`bundlewatch Node API`, () => {
     })
 
     it(`Works when files dont exist, shows warning`, async () => {
-        const result = await bundlewatchApi({
-            files: [
-                {
-                    path: './__testdata__/test-file-doesnt-exist.jpg',
-                    maxSize: '100kB',
-                },
-            ],
-        })
+        const result = await bundlewatchApi(
+            {
+                files: [
+                    {
+                        path: './__testdata__/test-file-doesnt-exist.jpg',
+                        maxSize: '100kB',
+                    },
+                ],
+            },
+            {
+                error: () => {},
+                pass: () => {},
+                fail: () => {},
+            },
+        )
 
         delete result.url
         expect(result).toMatchSnapshot()
@@ -64,22 +78,30 @@ describe(`bundlewatch Node API`, () => {
 
         // TODO: assert save was called
 
-        const result = await bundlewatchApi({
-            files: [
-                {
-                    path: './__testdata__/*.jpg',
-                    maxSize: '1MB',
+        const result = await bundlewatchApi(
+            {
+                files: [
+                    {
+                        path: './__testdata__/*.jpg',
+                        maxSize: '1MB',
+                    },
+                ],
+                ci: {
+                    githubAccessToken: MOCK_AUTH_TOKEN,
+                    repoOwner: MOCK_REPO.owner,
+                    repoName: MOCK_REPO.name,
+                    repoCurrentBranch: MOCK_REPO.currentBranch,
+                    repoBranchBase: MOCK_REPO.branchBase,
+                    commitSha: MOCK_REPO.branchBase,
                 },
-            ],
-            ci: {
-                githubAccessToken: MOCK_AUTH_TOKEN,
-                repoOwner: MOCK_REPO.owner,
-                repoName: MOCK_REPO.name,
-                repoCurrentBranch: MOCK_REPO.currentBranch,
-                repoBranchBase: MOCK_REPO.branchBase,
-                commitSha: MOCK_REPO.branchBase,
             },
-        })
+
+            {
+                error: () => {},
+                pass: () => {},
+                fail: () => {},
+            },
+        )
 
         delete result.url
         expect(result).toMatchSnapshot()
@@ -88,15 +110,23 @@ describe(`bundlewatch Node API`, () => {
     it('Throws validations error when using brotli compression without the package', async () => {
         let error
         try {
-            await bundlewatchApi({
-                files: [
-                    {
-                        path: './__testdata__/*.jpg',
-                        maxSize: '100kB',
-                    },
-                ],
-                defaultCompression: 'brotli',
-            })
+            await bundlewatchApi(
+                {
+                    files: [
+                        {
+                            path: './__testdata__/*.jpg',
+                            maxSize: '100kB',
+                        },
+                    ],
+                    defaultCompression: 'brotli',
+                },
+
+                {
+                    error: () => {},
+                    pass: () => {},
+                    fail: () => {},
+                },
+            )
         } catch (e) {
             error = e
         }
@@ -104,16 +134,23 @@ describe(`bundlewatch Node API`, () => {
     })
 
     it('Normalizes hash when given a normalizeFilenames option', async () => {
-        const result = await bundlewatchApi({
-            files: [
-                {
-                    path: './__testdata__/*.js',
-                    maxSize: '100kB',
-                },
-            ],
-            defaultCompression: 'none',
-            normalizeFilenames: '^.+?(\\.\\w+)\\.(?:js|css)$',
-        })
+        const result = await bundlewatchApi(
+            {
+                files: [
+                    {
+                        path: './__testdata__/*.js',
+                        maxSize: '100kB',
+                    },
+                ],
+                defaultCompression: 'none',
+                normalizeFilenames: '^.+?(\\.\\w+)\\.(?:js|css)$',
+            },
+            {
+                error: () => {},
+                pass: () => {},
+                fail: () => {},
+            },
+        )
 
         delete result.url
         expect(result.fullResults[0].filePath).toMatchInlineSnapshot(

--- a/src/app/reporting/GitHubService/index.js
+++ b/src/app/reporting/GitHubService/index.js
@@ -21,6 +21,8 @@ const getContextForFilePath = (filePath) => {
 }
 
 class GitHubService {
+    hasReported = false
+
     constructor({ repoOwner, repoName, commitSha, githubAccessToken }) {
         this.repoOwner = repoOwner
         this.repoName = repoName
@@ -93,14 +95,17 @@ class GitHubService {
     }
 
     pass({ message, url }) {
+        this.hasReported = true
         return this.update(message, url, 'success')
     }
 
     fail({ message, url, filePath }) {
+        this.hasReported = true
         return this.update(message, url, 'failure', filePath)
     }
 
     error({ message }) {
+        this.hasReported = true
         return this.update(message, undefined, 'error')
     }
 }

--- a/src/bin/determineConfig.js
+++ b/src/bin/determineConfig.js
@@ -78,6 +78,7 @@ const determineConfig = (cliOptions) => {
             files,
             defaultCompression: cliOptions.compression || 'gzip',
             normalizeFilenames: cliOptions.normalize,
+            maxTimeout: cliOptions.maxTimeout || 1000 * 60 * 15, // default of 15 minutes
         }
     }
 

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -107,15 +107,14 @@ const mainSafe = async () => {
     try {
         const errorCode = await Promise.race([
             main(githubService),
-            (async () => {
-                await new Promise((resolve) => {
-                    if (config.maxTimeout != null) {
-                        setTimeout(resolve, config.maxTimeout)
-                    }
-                    // hang forever if maxTimeout is set to null
-                })
+            new Promise((resolve) => {
+                if (config.maxTimeout != null) {
+                    setTimeout(resolve, config.maxTimeout)
+                }
+                // hang forever if maxTimeout is set to null
+            }).then(() => {
                 throw new Error('Max timeout exceeded')
-            })(),
+            }),
         ])
         return errorCode
     } catch (error) {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

Addressing https://github.com/bundlewatch/bundlewatch/issues/456, I moved the github service initialization outside of code context that involves bundlewatch APIs and other opaque side-effects laden things, so that it can (hopefully always) fail the action when unhandled errors happen, rather than never reporting a status to github like was frequently happening (as per the mentioned issue)

I also added a maxTimeout config option.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

bugfix

**Does this PR introduce a breaking change?**
 No 
