### PR TITLE
fix: Allow execution even if package.json does not exist on CLI

### DIFF
--- a/src/bin/determineConfig.js
+++ b/src/bin/determineConfig.js
@@ -56,7 +56,7 @@ const getConfigFileContents = (configFilePath) => {
 }
 
 const determineConfig = (cliOptions) => {
-    const pkgJson = (readPkgUp.sync() || {}).packageJson
+    const pkgJson = (readPkgUp.sync() || {}).packageJson || {}
     let pkgJsonbundlewatch = pkgJson.bundlewatch
 
     if (cliOptions.args && cliOptions.args.length > 0) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

Hi, I fixed bug #434.

**What kind of change does this PR introduce?**

A bugfix

**Did you add tests for your changes?**

No - Currently there are no CLI tests, so no tests were added for this change.

**If relevant, link to documentation update:**

N/A

**Summary**

This PR fixed issue #434.

Previously, bundlewatch would throw a TypeError when attempting to run in a directory without a `package.json` file, even when a configuration was explicitly provided via the `--config` flag. This occurred because the bundlewatch always treated `package.json` as a required file, resulting in an unhandled exception.

To fix this issue, I modified the code so as not to throw an error when package.json doesn't exist.

**Does this PR introduce a breaking change?**

No

**Other information**