### PR TITLE
Upgrade Axios to 1.8.4 due to major vulnerability with older versions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,18 @@
                 "modules": "commonjs"
             }
         ]
-    ]
+    ],
+    "env": {
+        "test": {
+            "presets": [
+                [
+                    "@babel/preset-env",
+                    {
+                        "targets": { "node": "current" },
+                        "modules": "commonjs"
+                    }
+                ]
+            ]
+        }
+    }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+    presets: [
+        [
+            '@babel/preset-env',
+            {
+                targets: {
+                    node: 'current',
+                },
+                modules: 'commonjs',
+            },
+        ],
+    ],
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "author": "bundlewatch",
     "license": "MIT",
     "dependencies": {
-        "axios": "^0.28.0",
+        "axios": "^1.8.4",
         "bytes": "^3.1.1",
         "chalk": "^4.0.0",
         "ci-env": "^1.17.0",
@@ -44,7 +44,7 @@
         "@babel/core": "^7.24.9",
         "@babel/eslint-parser": "^7.24.8",
         "@babel/preset-env": "^7.24.8",
-        "axios-mock-adapter": "^1.20.0",
+        "axios-mock-adapter": "^2.1.0",
         "coveralls": "^3.1.1",
         "del-cli": "^5.1.0",
         "eslint": "^8.6.0",
@@ -62,7 +62,13 @@
     "jest": {
         "testEnvironment": "node",
         "collectCoverage": true,
-        "coverageDirectory": "artifacts/test_results/jest/coverage"
+        "coverageDirectory": "artifacts/test_results/jest/coverage",
+        "transform": {
+            "^.+\\.js$": "babel-jest"
+        },
+        "transformIgnorePatterns": [
+            "node_modules/(?!(axios)/)"
+        ]
     },
     "engines": {
         "node": ">=16"

--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -1,9 +1,8 @@
+import bundlewatchApi from '.'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 
 const networkMock = new MockAdapter(axios)
-
-import bundlewatchApi from '.'
 
 describe(`bundlewatch Node API`, () => {
     it('Works with basic options', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1794,21 +1794,20 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios-mock-adapter@^1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz#21f5b4b625306f43e8c05673616719da86e20dcb"
-  integrity sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==
+axios-mock-adapter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz#25ab2d7558f915e391744a40bbeb7374ad5985a4"
+  integrity sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==
   dependencies:
     fast-deep-equal "^3.1.3"
-    is-blob "^2.1.0"
     is-buffer "^2.0.5"
 
-axios@^0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.28.0.tgz#801a4d991d0404961bccef46800e1170f8278c89"
-  integrity sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==
+axios@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
   dependencies:
-    follow-redirects "^1.15.0"
+    follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -2871,10 +2870,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
-follow-redirects@^1.15.0:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -3284,11 +3283,6 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
-
-is-blob@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-blob/-/is-blob-2.1.0.tgz#e36cd82c90653f1e1b930f11baf9c64216a05385"
-  integrity sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==
 
 is-boolean-object@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Dependency upgrade

**Did you add tests for your changes?**
N/A

**If relevant, link to documentation update:**
N/A

**Summary**
Serious vulnerability in earlier versions of Axios: https://security.snyk.io/vuln/SNYK-JS-AXIOS-7361793

**Does this PR introduce a breaking change?**

Nope!
**Other information**

There were some Babel changes that I don't have 110% confidence about. Please critique as you see fit!
